### PR TITLE
Transform HTML only based on response headers during dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Check out the [starter repo](https://github.com/nititech/php-vite-starter) for a
 
 | Version | Feature                                                                                                     |
 | ------- | ----------------------------------------------------------------------------------------------------------- |
+| 1.0.62  | HTML transforms are now only applied to HTML contents during dev                                            |
 | 1.0.60  | Fixed inline module transpiling -> PHP code is being properly inserted into transpiled inline module chunks |
 | 1.0.55  | Fixed pure PHP file processing                                                                              |
 | 1.0.50  | Using native Rollup pipeline to generate bundle -> proper error messages during build                       |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-php",
-	"version": "1.0.61",
+	"version": "1.0.62",
 	"author": "Nikita 'donnikitos' Nitichevski <me@donnikitos.com> (https://donnikitos.com/)",
 	"repository": {
 		"type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,11 +214,19 @@ function usePHP(cfg: UsePHPConfig = {}): Plugin[] {
 											.end();
 									});
 
-									const out = await server.transformIndexHtml(
-										requestUrl,
-										phpResult.content,
-										'/' + entryPathname,
-									);
+									let out = phpResult.content;
+
+									if (
+										phpResult.headers[
+											'content-type'
+										]?.includes('html')
+									) {
+										out = await server.transformIndexHtml(
+											requestUrl,
+											out,
+											'/' + entryPathname,
+										);
+									}
 
 									res.writeHead(phpResult.statusCode || 200, {
 										...req.headers,


### PR DESCRIPTION
All responses had a script tag injected, see issue #27.
This code determines if the PHP response has a `Content-Type: */html` header and transforms only those.